### PR TITLE
version 1_7 out of gradle files

### DIFF
--- a/build-common-plugin.gradle
+++ b/build-common-plugin.gradle
@@ -1,9 +1,5 @@
 android {
     defaultConfig {
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_7
-            targetCompatibility JavaVersion.VERSION_1_7
-        }
     }
 
     repositories {
@@ -18,10 +14,6 @@ android {
 
 ext.postBuildExtras = {
     android {
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_7
-            targetCompatibility JavaVersion.VERSION_1_7
-        }
     }
 }
 

--- a/src/build-extras.gradle
+++ b/src/build-extras.gradle
@@ -1,8 +1,4 @@
 ext.postBuildExtras = {
     android {
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_7
-            targetCompatibility JavaVersion.VERSION_1_7
-        }
     }
 }


### PR DESCRIPTION
Die JavaVersion.VERSION_1_7 soll aus den Gradle Files entfernt werden um ein herunterziehen der Java Version von 1.8 auf 1.7 zu verhindern.