### PR TITLE
Deprecated 'compile' usage

### DIFF
--- a/build-common-plugin.gradle
+++ b/build-common-plugin.gradle
@@ -8,7 +8,7 @@ android {
     }
 
     dependencies {
-        compile 'com.android.support:appcompat-v7:25.3.1'
+        implementation 'com.android.support:appcompat-v7:25.3.1'
     }
 }
 


### PR DESCRIPTION
'compile' is deprecated and invalid in gradle version 7.4.2 ending with exception and failed build